### PR TITLE
Define VulkanBinPath in one file

### DIFF
--- a/Source/Chapter02Shaders/Chapter02Shaders.csproj
+++ b/Source/Chapter02Shaders/Chapter02Shaders.csproj
@@ -13,9 +13,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
 
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />

--- a/Source/Chapter03PipelineSetup/Chapter03PipelineSetup.csproj
+++ b/Source/Chapter03PipelineSetup/Chapter03PipelineSetup.csproj
@@ -14,10 +14,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter04PipelineStages/Chapter04PipelineStages.csproj
+++ b/Source/Chapter04PipelineStages/Chapter04PipelineStages.csproj
@@ -14,10 +14,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter05SwapChain/Chapter05PipelineStages.csproj
+++ b/Source/Chapter05SwapChain/Chapter05PipelineStages.csproj
@@ -14,11 +14,7 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
+	
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter06VertexBuffers/Chapter06VertextBuffers.csproj
+++ b/Source/Chapter06VertexBuffers/Chapter06VertextBuffers.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter07FragmentInterpolation/Chapter07FragmentInterpolation.csproj
+++ b/Source/Chapter07FragmentInterpolation/Chapter07FragmentInterpolation.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter08DynamicViewports/Chapter08DynamicViewports.csproj
+++ b/Source/Chapter08DynamicViewports/Chapter08DynamicViewports.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter09PushConstants/Chapter09PushConstants.csproj
+++ b/Source/Chapter09PushConstants/Chapter09PushConstants.csproj
@@ -14,11 +14,7 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
+	
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter10TwoDTransformations/Chapter10TwoDTransformations.csproj
+++ b/Source/Chapter10TwoDTransformations/Chapter10TwoDTransformations.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter11RendererSystems/Chapter11RendererSystems.csproj
+++ b/Source/Chapter11RendererSystems/Chapter11RendererSystems.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter12EulerHomogeneousCoords/Chapter12EulerHomogeneousCoords.csproj
+++ b/Source/Chapter12EulerHomogeneousCoords/Chapter12EulerHomogeneousCoords.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter13ProjectionMatrices/Chapter13ProjectionMatrices.csproj
+++ b/Source/Chapter13ProjectionMatrices/Chapter13ProjectionMatrices.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter14CameraViewTransform/Chapter14CameraViewTransform.csproj
+++ b/Source/Chapter14CameraViewTransform/Chapter14CameraViewTransform.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter15GameLoopUserInput/Chapter15GameLoopUserInput.csproj
+++ b/Source/Chapter15GameLoopUserInput/Chapter15GameLoopUserInput.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter16IndexStagingBuffers/Chapter16IndexStagingBuffers.csproj
+++ b/Source/Chapter16IndexStagingBuffers/Chapter16IndexStagingBuffers.csproj
@@ -15,10 +15,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter17Loading3DModels/Chapter17Loading3DModels.csproj
+++ b/Source/Chapter17Loading3DModels/Chapter17Loading3DModels.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter18DiffuseShading/Chapter18DiffuseShading.csproj
+++ b/Source/Chapter18DiffuseShading/Chapter18DiffuseShading.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter19UniformBuffers/Chapter19UniformBuffers.csproj
+++ b/Source/Chapter19UniformBuffers/Chapter19UniformBuffers.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter19zNoCoherentAomSizeFix/Chapter19zNoCoherentAomSizeFix.csproj
+++ b/Source/Chapter19zNoCoherentAomSizeFix/Chapter19zNoCoherentAomSizeFix.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter20DescriptorSets/Chapter20DescriptorSets.csproj
+++ b/Source/Chapter20DescriptorSets/Chapter20DescriptorSets.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter20aDescriptorSetsNoBuilder/Chapter20aDescriptorSetsNoBuilder.csproj
+++ b/Source/Chapter20aDescriptorSetsNoBuilder/Chapter20aDescriptorSetsNoBuilder.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter21PointLights/Chapter21PointLights.csproj
+++ b/Source/Chapter21PointLights/Chapter21PointLights.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter22FragmentLighting/Chapter22FragmentLighting.csproj
+++ b/Source/Chapter22FragmentLighting/Chapter22FragmentLighting.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter24Billboards/Chapter24Billboards.csproj
+++ b/Source/Chapter24Billboards/Chapter24Billboards.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter25MultiplePointLights/Chapter25MultiplePointLights.csproj
+++ b/Source/Chapter25MultiplePointLights/Chapter25MultiplePointLights.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter26SpecularLighting/Chapter26SpecularLighting.csproj
+++ b/Source/Chapter26SpecularLighting/Chapter26SpecularLighting.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Chapter27AlphaBlending/Chapter27AlphaBlending.csproj
+++ b/Source/Chapter27AlphaBlending/Chapter27AlphaBlending.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <VulkanBinPath Condition="'$(VulkanBinPath)' == ''">C:\VulkanSDK\1.4.304.0\Bin</VulkanBinPath>
+  </PropertyGroup>
+</Project>

--- a/Source/Sandbox01MultiSampling/Sandbox01MultiSampling.csproj
+++ b/Source/Sandbox01MultiSampling/Sandbox01MultiSampling.csproj
@@ -16,10 +16,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<EmbeddedResource Include="**/*.spv" />
 	</ItemGroup>

--- a/Source/Sandbox02ImGui/Sandbox02ImGui.csproj
+++ b/Source/Sandbox02ImGui/Sandbox02ImGui.csproj
@@ -18,10 +18,6 @@
 		<PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
-	</PropertyGroup>
-
 	<!--<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<Optimize>false</Optimize>
 		<DebugType>full</DebugType>

--- a/Source/Sandbox03MeshShaders/Sandbox03MeshShaders.csproj
+++ b/Source/Sandbox03MeshShaders/Sandbox03MeshShaders.csproj
@@ -21,7 +21,6 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<VulkanBinPath>C:\VulkanSDK\1.3.239.0\Bin</VulkanBinPath>
 		<SpirVTarget>spv1.4</SpirVTarget>
 		<DestinationFolder>./Systems/SPIRV</DestinationFolder>
 	</PropertyGroup>


### PR DESCRIPTION
Directory.Build.props to define VulkanBinPath in one place, instead of every single .csproj
I updated it to version 1.4.304.0, the Directory.Build.props file contains a Conditional definition, meaning if a .csproj redefines the VulkanBinPath it overrides it